### PR TITLE
Disable static/native thread-local storage on Rust9x

### DIFF
--- a/compiler/rustc_target/src/spec/targets/i686_rust9x_windows_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/i686_rust9x_windows_gnu.rs
@@ -3,6 +3,7 @@ use crate::spec::{Target, cvs};
 pub(crate) fn target() -> Target {
     let mut base = super::i686_pc_windows_gnu::target();
     base.families = cvs!["windows", "rust9x"];
+    base.has_thread_local = false;
 
     base.metadata = crate::spec::TargetMetadata {
         description: Some("64-bit GNU rust9x (Windows XP 64-bit+)".into()),

--- a/compiler/rustc_target/src/spec/targets/i686_rust9x_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/targets/i686_rust9x_windows_msvc.rs
@@ -3,6 +3,7 @@ use crate::spec::{LinkerFlavor, Lld, Target, cvs};
 pub(crate) fn target() -> Target {
     let mut base = super::i686_pc_windows_msvc::target();
     base.families = cvs!["windows", "rust9x"];
+    base.has_thread_local = false;
 
     base.add_pre_link_args(
         LinkerFlavor::Msvc(Lld::No),

--- a/compiler/rustc_target/src/spec/targets/x86_64_rust9x_windows_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_rust9x_windows_gnu.rs
@@ -3,6 +3,7 @@ use crate::spec::{Target, cvs};
 pub(crate) fn target() -> Target {
     let mut base = super::x86_64_pc_windows_gnu::target();
     base.families = cvs!["windows", "rust9x"];
+    base.has_thread_local = false;
 
     base.metadata = crate::spec::TargetMetadata {
         description: Some("32-bit GNU rust9x (Windows 98/NT4+)".into()),

--- a/compiler/rustc_target/src/spec/targets/x86_64_rust9x_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_rust9x_windows_msvc.rs
@@ -7,6 +7,7 @@ pub(crate) fn target() -> Target {
     base.plt_by_default = false;
     base.max_atomic_width = Some(64);
     base.families = cvs!["windows", "rust9x"];
+    base.has_thread_local = false;
 
     base.add_pre_link_args(
         LinkerFlavor::Msvc(Lld::No),


### PR DESCRIPTION
Native thread-local storage is unreliable before Vista, so disable it explicitly on Rust9x targets.

NOTE: I haven't tested this on MSVC. See #12 for full discussion of this isue.